### PR TITLE
feat: add parallel multi-to-bi VCF converter

### DIFF
--- a/codes/S6_multi_to_bi.sh
+++ b/codes/S6_multi_to_bi.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# S6_multi_to_bi.sh
+# Convert multi-allelic VCF records to biallelic by keeping the two most
+# frequent alleles per site. Processes multiple VCF files in parallel using
+# GNU parallel.
+# Usage: S6_multi_to_bi.sh file1.vcf file2.vcf ...
+# Output files are written to biallelic_vcfs/<basename>_biallelic.vcf
+
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname "$0")
+mkdir -p biallelic_vcfs
+
+parallel -j 16 \
+  "python3 $SCRIPT_DIR/multi_to_bi.py {} biallelic_vcfs/{/.}_biallelic.vcf" \
+  ::: "$@"

--- a/codes/multi_to_bi.py
+++ b/codes/multi_to_bi.py
@@ -1,4 +1,6 @@
-from collections import defaultdict, Counter
+#!/usr/bin/env python3
+from collections import Counter
+import sys
 
 def parse_genotypes(allele_strs):
     """Convert genotype string to list of alleles, e.g. '0/1' => ['0', '1']."""
@@ -63,14 +65,12 @@ def filter_to_top_two(line):
     cols[9:] = new_samples
     return "\t".join(cols) + "\n"
 
-# --- Main execution ---
-vcf_in = "scaffold1_het_ref_filtered.vcf"
-vcf_out = "scaffold1_biallelic_filtered.vcf"
-
-with open(vcf_in) as fin, open(vcf_out, "w") as fout:
-    for line in fin:
-        if line.startswith("#"):
-            fout.write(line)
-        else:
-            fout.write(filter_to_top_two(line))
+if __name__ == "__main__":
+    vcf_in, vcf_out = sys.argv[1:3]
+    with open(vcf_in) as fin, open(vcf_out, "w") as fout:
+        for line in fin:
+            if line.startswith("#"):
+                fout.write(line)
+            else:
+                fout.write(filter_to_top_two(line))
 


### PR DESCRIPTION
## Summary
- restore `multi_to_bi.py` with CLI arguments to retain original allele filtering logic
- streamline `S6_multi_to_bi.sh` to mirror other parallel scripts and call the Python converter across multiple VCFs

## Testing
- `bash -n codes/S6_multi_to_bi.sh`
- `python3 -m py_compile codes/multi_to_bi.py`


------
https://chatgpt.com/codex/tasks/task_b_68a68d5fb658832688a6bc7184e85caf